### PR TITLE
Fixed bug where blockify could run while neither Spotify or Pulse was running

### DIFF
--- a/blockify/blockify.py
+++ b/blockify/blockify.py
@@ -98,6 +98,12 @@ class Blocklist(list):
 class Blockify(object):
 
     def __init__(self, blocklist):
+        try:
+            # Test if spotify is running
+            subprocess.check_output(["pidof", "spotify"])
+        except subprocess.CalledProcessError:
+            log.error("Process not found. Is Spotify running?")
+            sys.exit()
         self._automute = True
         self.blocklist = blocklist
         self.orglist = blocklist[:]


### PR DESCRIPTION
When blockify is running, it is impossible to mute via alsa since it detects constantly that it is not supposed to mute. This just adds a simple check to the constructor so that this is caught, even when Pulse is not running
