### PR TITLE
fixed dbus exception on exit

### DIFF
--- a/blockify/blockifyui.py
+++ b/blockify/blockifyui.py
@@ -267,9 +267,8 @@ class BlockifyUI(gtk.Window):
             try:
                 artist = self.spotify.get_song_artist()
                 title = self.spotify.get_song_title()
-            except AttributeError:
-                artist, title = song, "No song playing?"
-                self.use_dbus = False
+            except (DBusException, AttributeError):
+                artist = title = None
 
         # Sometimes song.split returns None, catch it here.
         if artist is None or title is None:


### PR DESCRIPTION
It would otherwise throw an exception if Spotify is exited before blockify. It also didn't appropriately change the title to "No song playing?" but kept the last track.
