### PR TITLE
Replace prefix search with substring search

### DIFF
--- a/blockify/blockify.py
+++ b/blockify/blockify.py
@@ -166,7 +166,7 @@ class Blockify(object):
             self.blocklist.__init__()
 
         for i in self.blocklist:
-            if self.current_song.startswith(i):
+            if i in self.current_song:
                 self.ad_found()
                 return True
 


### PR DESCRIPTION
In a few rare situations the best blocklist filter string is not a
prefix of the song. A substring search will handle these anomalies
correctly, with the caveat that it is inevitably much less conservative.

At least four instances of a pattern similar to the following have been
observed:

    FRESH LIGE NU Fra Filtr
    KLIK & LYT Fra Filtr

Here, "Filtr" is the desired filter string but isn't a prefix. The real
issue here is that the prefix filter is trivially bypassed in theory.
While I have only one example of this, the pattern is straight-forward.

An alternative could be to optionally try either a substring search or a
suffix search after a failed prefix search, letting users opt in to the
more dangerous behaviour. Personally I have had no issues with
substrings but my music consumption simply isn't big enough for my
experience to have much weight.

I confirmed that "Filtr" in this case is a suffix.