### PR TITLE
Start Spotify if not running.

### DIFF
--- a/blockify/util.py
+++ b/blockify/util.py
@@ -83,8 +83,9 @@ def get_default_options():
         "general": {
             "autodetect": True,
             "automute": True,
-            "substring_search": False
-            },
+            "substring_search": False,
+            "start_spotify": "no"
+        },
         "cli": {
             "update_interval": 200,
             "unmute_delay": 700
@@ -117,7 +118,7 @@ def load_options():
     except Exception as e:
         log.error("Could not read config file: {}. Using default options.".format(e))
     else:
-        option_tuples = [("general", "autodetect", "bool"), ("general", "automute", "bool"), ("general", "substring_search", "bool"),
+        option_tuples = [("general", "autodetect", "bool"), ("general", "automute", "bool"), ("general", "start_spotify", "str"), ("general", "substring_search", "bool"),
           ("cli", "update_interval", "int"), ("cli", "unmute_delay", "int"),
           ("gui", "use_cover_art", "bool"), ("gui", "autohide_cover", "bool"), ("gui", "update_interval", "int"), ("gui", "unmute_delay", "int"),
           ("interlude", "use_interlude_music", "bool"), ("interlude", "start_shuffled", "bool"), ("interlude", "autoresume", "bool"),


### PR DESCRIPTION
Based on work from @Fullmono's #21.

Originally, @mikar did not like Blockify to start automatically Spotify so I added a new entry in the configuration file which can control this. 

By default, it is set to "no", which means that Spotify will not be started by Blockify. Other possible options are "native" which runs the preview of the native Spotify client and "wine" which is currently unsupported. I hope that someone who is using Wine can do this.