### PR TITLE
Insert missing decode for subprocess output

### DIFF
--- a/blockify/cli.py
+++ b/blockify/cli.py
@@ -384,7 +384,7 @@ class Blockify(object):
     def is_muted(self):
         for channel in self.channels:
             output = subprocess.check_output(["amixer", "get", channel])
-            if "[off]" in output:
+            if "[off]" in output.decode("utf-8"):
                 return True
         return False
 


### PR DESCRIPTION
Subprocess bytes output in is_muted (line 386) needs to be decoded before checking for substring "[off]" in line 387. Failing to do so yields a "TypeError: a bytes-like object is required, not 'str'".