### PR TITLE
Fix  #62

### DIFF
--- a/blockify/util.py
+++ b/blockify/util.py
@@ -147,7 +147,7 @@ def save_options(CONFIG_DIR, options):
     for section in sections:
         config.add_section(section)
         for k, v in options[section].items():
-            config.set(section, k, v)
+            config.set(section, k, str(v))
 
     with codecs.open(configfile, "w", encoding="utf-8") as f:
         config.write(f)


### PR DESCRIPTION
ConfigParser().set only accept strings but get_default_options() returns also integers and booleans. So the program crash if it try to create a new config file.