### PR TITLE
added link to correct spotify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Blockify is a linux only application that allows you to automatically mute songs
 - Pulseaudio
 - Wmctrl
 - Gstreamer1.0 (including the plugins you need for the audio formats you want to be able to play as interlude music)
-- Spotify > 1.0.12
+- Spotify > 1.0.12 (to get the latest version follow the instructions given here [Spotify-Client-1-x-beta-] (https://community.spotify.com/t5/Spotify-Community-Blog/Spotify-Client-1-x-beta-for-Linux-has-been-released/ba-p/1147084.))
 
 ##### Dependencies
 Before installing blockify, please make sure you have the appropriate dependencies installed:  


### PR DESCRIPTION
Blockify requires Spotify > 1.0.12. If you install Spotify via https://www.spotify.com/nl/download/linux/, you end up with an old version and blockify does not work (tested on Ubuntu 14.04).
As a fix, use the official instructions for the beta spotify version; https://community.spotify.com/t5/Spotify-Community-Blog/Spotify-Client-1-x-beta-for-Linux-has-been-released/ba-p/1147084.
I have updated the readme and added this link.