### PR TITLE
Update README with pip instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,28 @@ sudo apt-get install spotify-client
 sudo apt-get install git python3-pip python3-gst-1.0 python3-requests python3-docopt python3-setuptools wmctrl
 ```
 
-Install routine:  
+Preparation (for Fedora):
+```bash
+# Install rpmfusion repos: https://rpmfusion.org/Configuration#Command_Line_Setup_using_rpm
+dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+# Install snapd: https://www.spotify.com/it/download/linux/
+dnf install -y snapd
+# Install spotify from the snap store
+snap install spotify
+
+# Install blockify dependencies
+dnf install -y git python3-pip python3-gstreamer1 python3-devel python3-requests python3-docopt python3-setuptools wmctrl
+```
+
+Install blockify:  
 ```bash
 # Install blockify
 sudo pip3 install git+https://github.com/serialoverflow/blockify
 echo -e '[Desktop Entry]\nName=Blockify\nComment=Blocks Spotify commercials\nExec=blockify-ui\nIcon='$(python3 -c 'import pkg_resources; print(pkg_resources.resource_filename("blockify", "data/icon-red-512.png"))')'\nType=Application\nCategories=AudioVideo' | sudo tee /usr/share/applications/blockify.desktop
 ```
+
+If you want to install blockify only for your user, use `pip3 install --user git+https://github.com/serialoverflow/blockify`.
+
 
 ## Usage
 


### PR DESCRIPTION
I tried installing the RPM from the OpenSUSE repo with the repository `home:fusion809`, but there's no `blockify` inside.
I also tried installing directly the RPM from https://software.opensuse.org/download.html?project=home%3Afusion809&package=blockify, but the `blockify` program produced the following traceback:
```Traceback (most recent call last):
  File "/usr/bin/blockify", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3112, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3096, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3125, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 578, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 895, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 781, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'blockify==3.6.3' distribution was not found and is required by the application
```
Maybe some patched dependencies from the repo are required?

The pip method is the only method that installed a working version.
Tested on f29 with python 3.7.